### PR TITLE
Fix >=0.12 interpolation

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -140,7 +140,7 @@ data "aws_iam_policy_document" "state_force_ssl" {
     actions = ["s3:*"]
     effect  = "Deny"
     resources = [
-      "${aws_s3_bucket.state.arn}",
+      aws_s3_bucket.state.arn,
       "${aws_s3_bucket.state.arn}/*"
     ]
     condition {
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "replica_force_ssl" {
     actions = ["s3:*"]
     effect  = "Deny"
     resources = [
-      "${aws_s3_bucket.replica.arn}",
+      aws_s3_bucket.replica.arn,
       "${aws_s3_bucket.replica.arn}/*"
     ]
     condition {


### PR DESCRIPTION
TF > 0.11 throws the following warning:

```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/remote_state/bucket.tf line 143, in data "aws_iam_policy_document" "state_force_ssl":
 143:       "${aws_s3_bucket.state.arn}",
```

This change fixes that