### PR TITLE
Fixes 'Error putting S3 policy' on terraform apply 

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -222,8 +222,9 @@ resource "aws_s3_bucket" "replica" {
 }
 
 resource "aws_s3_bucket_policy" "state_force_ssl" {
-  bucket = aws_s3_bucket.state.id
-  policy = data.aws_iam_policy_document.state_force_ssl.json
+  depends_on = [aws_s3_bucket_public_access_block.state]
+  bucket     = aws_s3_bucket.state.id
+  policy     = data.aws_iam_policy_document.state_force_ssl.json
 }
 
 resource "aws_s3_bucket_public_access_block" "replica" {
@@ -303,9 +304,10 @@ resource "aws_s3_bucket" "state" {
 }
 
 resource "aws_s3_bucket_policy" "replica_force_ssl" {
-  provider = aws.replica
-  bucket   = aws_s3_bucket.replica.id
-  policy   = data.aws_iam_policy_document.replica_force_ssl.json
+  depends_on = [aws_s3_bucket_public_access_block.replica]
+  provider   = aws.replica
+  bucket     = aws_s3_bucket.replica.id
+  policy     = data.aws_iam_policy_document.replica_force_ssl.json
 }
 
 resource "aws_s3_bucket_public_access_block" "state" {


### PR DESCRIPTION
I have been getting the following errors when doing a `terrform apply` using the module : - 

```
Error: Error putting S3 policy: OperationAborted: A conflicting conditional operation is currently in progress against this resource. Please try again.
	status code: 409, request id: 731DE7B56FE9B4FF, host id:

  on .terraform/modules/tf_remote_state/bucket.tf line 224, in resource "aws_s3_bucket_policy" "state_force_ssl":
 224: resource "aws_s3_bucket_policy" "state_force_ssl" {



Error: Error putting S3 policy: OperationAborted: A conflicting conditional operation is currently in progress against this resource. Please try again.
	status code: 409, request id: EE9BACB85562B1CD, host id: 

  on .terraform/modules/tf_remote_state/bucket.tf line 305, in resource "aws_s3_bucket_policy" "replica_force_ssl":
 305: resource "aws_s3_bucket_policy" "replica_force_ssl" {

```
I've added a `depends_on` to the force_ssl policy referencing the `aws_s3_bucket_public_access_block`for both replica and state, this fixes the issue and provides a clean apply each time as one will always happen after the other. 