### PR TITLE
Update README - Add lock table

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,17 @@ Once resources are created, you can configure your terraform files to use the S3
 ```hcl
 terraform {
   backend "s3" {
-    bucket  = "THE_NAME_OF_THE_STATE_BUCKET"
-    key     = "some_environment/terraform.tfstate"
-    region  = "us-east-1"
-    encrypt = true
-    kms_key_id = "THE_ID_OF_THE_KMS_KEY"
+    bucket         = "THE_NAME_OF_THE_STATE_BUCKET"
+    key            = "some_environment/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    kms_key_id     = "THE_ID_OF_THE_KMS_KEY"
+    dynamodb_table = "THE_ID_OF_THE_DYNAMODB_TABLE"
   }
 }
 ```
 
-`THE_NAME_OF_THE_STATE_BUCKET` and `THE_ID_OF_THE_KMS_KEY` can be replaced by `state_bucket.bucket`  and `kms_key.id`  in outputs from this module respectively.
+`THE_NAME_OF_THE_STATE_BUCKET`, `THE_ID_OF_THE_DYNAMODB_TABLE` and `THE_ID_OF_THE_KMS_KEY` can be replaced by `state_bucket.bucket`, `dynamodb_table.id` and `kms_key.id`  in outputs from this module respectively.
 
 See [the official document](https://www.terraform.io/docs/backends/types/s3.html#example-configuration) for more detail.
 


### PR DESCRIPTION
The README file example lacked the dynamodb locking table configuration, so I've added it.