### PR TITLE
make s3 bucket replication optional

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -1,6 +1,6 @@
 locals {
   define_lifecycle_rule  = var.noncurrent_version_expiration != null || length(var.noncurrent_version_transitions) > 0
-  replication_role_count = var.iam_role_arn == null ? 1 : 0
+  replication_role_count = var.iam_role_arn == null && var.enable_replication ? 1 : 0
 }
 
 #---------------------------------------------------------------------------------------------------
@@ -15,6 +15,7 @@ resource "aws_kms_key" "this" {
 }
 
 resource "aws_kms_key" "replica" {
+  count    = var.enable_replication ? 1 : 0
   provider = aws.replica
 
   description             = var.kms_key_description
@@ -85,7 +86,7 @@ resource "aws_iam_policy" "replication" {
         "s3:ReplicateDelete"
       ],
       "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.replica.arn}/*"
+      "Resource": "${join("", aws_s3_bucket.replica.*.arn)}/*"
     },
     {
       "Effect": "Allow",
@@ -108,12 +109,12 @@ resource "aws_iam_policy" "replication" {
         "kms:Encrypt",
         "kms:GenerateDataKey"
       ],
-      "Resource": "${aws_kms_key.replica.arn}",
+      "Resource": "${join("", aws_kms_key.replica.*.arn)}",
       "Condition": {
         "StringLike": {
-          "kms:ViaService": "s3.${data.aws_region.replica.name}.amazonaws.com",
+          "kms:ViaService": "s3.${join("", data.aws_region.replica.*.name)}.amazonaws.com",
           "kms:EncryptionContext:aws:s3:arn": [
-            "${aws_s3_bucket.replica.arn}/*"
+            "${join("", aws_s3_bucket.replica.*.arn)}/*"
           ]
         }
       }
@@ -156,13 +157,14 @@ data "aws_iam_policy_document" "state_force_ssl" {
 }
 
 data "aws_iam_policy_document" "replica_force_ssl" {
+  count = var.enable_replication ? 1 : 0
   statement {
     sid     = "AllowSSLRequestsOnly"
     actions = ["s3:*"]
     effect  = "Deny"
     resources = [
-      aws_s3_bucket.replica.arn,
-      "${aws_s3_bucket.replica.arn}/*"
+      join("", aws_s3_bucket.replica.*.arn),
+      "${join("", aws_s3_bucket.replica.*.arn)}/*"
     ]
     condition {
       test     = "Bool"
@@ -182,10 +184,12 @@ data "aws_region" "state" {
 }
 
 data "aws_region" "replica" {
+  count    = var.enable_replication ? 1 : 0
   provider = aws.replica
 }
 
 resource "aws_s3_bucket" "replica" {
+  count    = var.enable_replication ? 1 : 0
   provider = aws.replica
 
   bucket_prefix = var.replica_bucket_prefix
@@ -228,8 +232,9 @@ resource "aws_s3_bucket_policy" "state_force_ssl" {
 }
 
 resource "aws_s3_bucket_public_access_block" "replica" {
+  count    = var.enable_replication ? 1 : 0
   provider = aws.replica
-  bucket   = aws_s3_bucket.replica.id
+  bucket   = join("", aws_s3_bucket.replica.*.id)
 
   block_public_acls       = true
   block_public_policy     = true
@@ -263,24 +268,27 @@ resource "aws_s3_bucket" "state" {
     }
   }
 
-  replication_configuration {
-    role = var.iam_role_arn != null ? var.iam_role_arn : aws_iam_role.replication[0].arn
+  dynamic "replication_configuration" {
+    for_each = var.enable_replication == true ? [1] : []
+    content {
+      role = var.iam_role_arn != null ? var.iam_role_arn : aws_iam_role.replication[0].arn
 
-    rules {
-      id     = "replica_configuration"
-      prefix = ""
-      status = "Enabled"
+      rules {
+        id     = "replica_configuration"
+        prefix = ""
+        status = "Enabled"
 
-      source_selection_criteria {
-        sse_kms_encrypted_objects {
-          enabled = true
+        source_selection_criteria {
+          sse_kms_encrypted_objects {
+            enabled = true
+          }
         }
-      }
 
-      destination {
-        bucket             = aws_s3_bucket.replica.arn
-        storage_class      = "STANDARD"
-        replica_kms_key_id = aws_kms_key.replica.arn
+        destination {
+          bucket             = aws_s3_bucket.replica[0].arn
+          storage_class      = "STANDARD"
+          replica_kms_key_id = aws_kms_key.replica[0].arn
+        }
       }
     }
   }
@@ -312,10 +320,11 @@ resource "aws_s3_bucket" "state" {
 }
 
 resource "aws_s3_bucket_policy" "replica_force_ssl" {
+  count      = var.enable_replication ? 1 : 0
   depends_on = [aws_s3_bucket_public_access_block.replica]
   provider   = aws.replica
-  bucket     = aws_s3_bucket.replica.id
-  policy     = data.aws_iam_policy_document.replica_force_ssl.json
+  bucket     = join("", aws_s3_bucket.replica.*.id)
+  policy     = join("", data.aws_iam_policy_document.replica_force_ssl.*.json)
 }
 
 resource "aws_s3_bucket_public_access_block" "state" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "state_bucket" {
 
 output "replica_bucket" {
   description = "The S3 bucket to replicate the state S3 bucket."
-  value       = aws_s3_bucket.replica
+  value       = aws_s3_bucket.replica.*
 }
 
 output "dynamodb_table" {

--- a/variables.tf
+++ b/variables.tf
@@ -44,12 +44,12 @@ variable "kms_key_enable_key_rotation" {
 #---------------------------------------------------------------------------------------------------
 variable "state_bucket_prefix" {
   description = "Creates a unique state bucket name beginning with the specified prefix."
-  default     = "tf-remote-state"
+  default     = "tf-remote-state-iy2-"
 }
 
 variable "replica_bucket_prefix" {
   description = "Creates a unique replica bucket name beginning with the specified prefix."
-  default     = "tf-remote-state-replica"
+  default     = "tf-remote-state-replica-iy2-"
 }
 
 variable "iam_role_arn" {
@@ -119,10 +119,16 @@ variable "s3_logging_target_prefix" {
 #---------------------------------------------------------------------------------------------------
 variable "dynamodb_table_name" {
   description = "The name of the DynamoDB table to use for state locking."
-  default     = "tf-remote-state-lock"
+  default     = "tf-remote-state-lock-iy2"
 }
 
 variable "dynamodb_table_billing_mode" {
   description = "Controls how you are charged for read and write throughput and how you manage capacity."
   default     = "PAY_PER_REQUEST"
+}
+
+variable "enable_replication" {
+  type        = bool
+  default     = true
+  description = "Set this to true to enable replication"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -44,12 +44,12 @@ variable "kms_key_enable_key_rotation" {
 #---------------------------------------------------------------------------------------------------
 variable "state_bucket_prefix" {
   description = "Creates a unique state bucket name beginning with the specified prefix."
-  default     = "tf-remote-state-iy2-"
+  default     = "tf-remote-state"
 }
 
 variable "replica_bucket_prefix" {
   description = "Creates a unique replica bucket name beginning with the specified prefix."
-  default     = "tf-remote-state-replica-iy2-"
+  default     = "tf-remote-state-replica"
 }
 
 variable "iam_role_arn" {
@@ -119,7 +119,7 @@ variable "s3_logging_target_prefix" {
 #---------------------------------------------------------------------------------------------------
 variable "dynamodb_table_name" {
   description = "The name of the DynamoDB table to use for state locking."
-  default     = "tf-remote-state-lock-iy2"
+  default     = "tf-remote-state-lock"
 }
 
 variable "dynamodb_table_billing_mode" {

--- a/variables.tf
+++ b/variables.tf
@@ -130,5 +130,5 @@ variable "dynamodb_table_billing_mode" {
 variable "enable_replication" {
   type        = bool
   default     = true
-  description = "Set this to true to enable replication"
+  description = "Set this to true to enable S3 bucket replication in another region"
 }


### PR DESCRIPTION
For dev env or less important env, we might want to disable s3 replication.
Added `enable_replication` variable to make it work.