### PR TITLE
add moved configurations for replica bucket related resources

### DIFF
--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,20 @@
+moved {
+  from = aws_kms_key.replica
+  to   = aws_kms_key.replica[0]
+}
+
+moved {
+  from = aws_s3_bucket.replica
+  to   = aws_s3_bucket.replica[0]
+}
+
+moved {
+  from = aws_s3_bucket_public_access_block.replica
+  to   = aws_s3_bucket_public_access_block.replica[0]
+}
+
+moved {
+  from = aws_s3_bucket_policy.replica_force_ssl
+  to   = aws_s3_bucket_policy.replica_force_ssl[0]
+}
+


### PR DESCRIPTION
# What
add `moved` configurations for replica bucket related resources. 
# Why
I've seen some destroy and re-creation of some existing resources when I update from 0.5 -> 0.7