### PR TITLE
Added the capability to specify an alias for the KMS Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ See [the official document](https://www.terraform.io/docs/backends/types/s3.html
 | <a name="input_iam_policy_name_prefix"></a> [iam\_policy\_name\_prefix](#input\_iam\_policy\_name\_prefix) | Creates a unique name beginning with the specified prefix. | `string` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | Use IAM role of specified ARN for s3 replication instead of creating it. | `string` | no |
 | <a name="input_iam_role_name_prefix"></a> [iam\_role\_name\_prefix](#input\_iam\_role\_name\_prefix) | Creates a unique name beginning with the specified prefix. | `string` | no |
+| <a name="input_kms_key_alias"></a> [kms\_key\_alias](#input\_kms\_key\_alias) | The alias for the KMS key as viewed in AWS console. It will be automatically prefixed with `alias/` | `string` | no |
 | <a name="input_kms_key_deletion_window_in_days"></a> [kms\_key\_deletion\_window\_in\_days](#input\_kms\_key\_deletion\_window\_in\_days) | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. | `number` | no |
 | <a name="input_kms_key_description"></a> [kms\_key\_description](#input\_kms\_key\_description) | The description of the key as viewed in AWS console. | `string` | no |
 | <a name="input_kms_key_enable_key_rotation"></a> [kms\_key\_enable\_key\_rotation](#input\_kms\_key\_enable\_key\_rotation) | Specifies whether key rotation is enabled. | `bool` | no |
@@ -127,6 +128,7 @@ See [the official document](https://www.terraform.io/docs/backends/types/s3.html
 |------|-------------|
 | <a name="output_dynamodb_table"></a> [dynamodb\_table](#output\_dynamodb\_table) | The DynamoDB table to manage lock states. |
 | <a name="output_kms_key"></a> [kms\_key](#output\_kms\_key) | The KMS customer master key to encrypt state buckets. |
+| <a name="output_kms_key_alias"></a> [kms\_key\_alias](#output\_kms\_key\_alias) | The alias of the KMS customer master key used to encrypt state buckets. |
 | <a name="output_replica_bucket"></a> [replica\_bucket](#output\_replica\_bucket) | The S3 bucket to replicate the state S3 bucket. |
 | <a name="output_state_bucket"></a> [state\_bucket](#output\_state\_bucket) | The S3 bucket to store the remote state file. |
 | <a name="output_terraform_iam_policy"></a> [terraform\_iam\_policy](#output\_terraform\_iam\_policy) | The IAM Policy to access remote state environment. |

--- a/bucket.tf
+++ b/bucket.tf
@@ -17,6 +17,11 @@ resource "aws_kms_key" "this" {
   tags = var.tags
 }
 
+resource "aws_kms_alias" "this" {
+  name          = "alias/${var.kms_key_alias}"
+  target_key_id = aws_kms_key.this.key_id
+}
+
 #---------------------------------------------------------------------------------------------------
 # Bucket Policies
 #---------------------------------------------------------------------------------------------------

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "kms_key" {
   value       = aws_kms_key.this
 }
 
+output "kms_key_alias" {
+  description = "The alias of the KMS customer master key used to encrypt state buckets."
+  value       = aws_kms_key.this
+}
+
 output "state_bucket" {
   description = "The S3 bucket to store the remote state file."
   value       = aws_s3_bucket.state

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,12 @@ variable "terraform_iam_policy_name_prefix" {
 # KMS Key for Encrypting S3 Buckets
 #---------------------------------------------------------------------------------------------------
 
+variable "kms_key_alias" {
+  description = "The alias for the KMS key as viewed in AWS console. It will be automatically prefixed with `alias/`"
+  type        = string
+  default     = "tf-remote-state-key"
+}
+
 variable "kms_key_description" {
   description = "The description of the key as viewed in AWS console."
   type        = string


### PR DESCRIPTION
Hey. I think it might be nice to have the ability to specify an alias for the KMS key. That way, when someone wants to get that key in another repo, it can use a data source and specify the friendly  name of the alias instead passing in the ID. 

Also, if the key changes underneath, the alias name can be preserved in different repos. 