### PR TITLE
add: allow use of permissions_boundary on iam_role

### DIFF
--- a/dynamo.tf
+++ b/dynamo.tf
@@ -10,9 +10,9 @@ locals {
 }
 
 resource "aws_dynamodb_table" "lock" {
-  name         = var.dynamodb_table_name
-  billing_mode = var.dynamodb_table_billing_mode
-  hash_key     = local.lock_key_id
+  name           = var.dynamodb_table_name
+  billing_mode   = var.dynamodb_table_billing_mode
+  hash_key       = local.lock_key_id
 
   attribute {
     name = local.lock_key_id
@@ -27,6 +27,15 @@ resource "aws_dynamodb_table" "lock" {
   point_in_time_recovery {
     enabled = true
   }
+
+  dynamic "replica" {
+    for_each = var.enable_replication == true ? [1] : []
+    content {
+      region_name = data.aws_region.replica[0].name
+      kms_key_arn = var.dynamodb_enable_server_side_encryption ? aws_kms_key.replica[0].arn : null
+    }
+  }
+  stream_enabled = var.dynamodb_enable_server_side_encryption ? true : null
 
   tags = var.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "kms_key" {
 }
 
 output "kms_key_alias" {
-  description = "The alias of the KMS customer master key used to encrypt state buckets."
+  description = "The alias of the KMS customer master key used to encrypt state bucket and dynamodb."
   value       = aws_kms_key.this
 }
 
@@ -15,12 +15,17 @@ output "state_bucket" {
 
 output "replica_bucket" {
   description = "The S3 bucket to replicate the state S3 bucket."
-  value       = aws_s3_bucket.replica.*
+  value       = try(aws_s3_bucket.replica[0], null)
 }
 
 output "dynamodb_table" {
   description = "The DynamoDB table to manage lock states."
   value       = aws_dynamodb_table.lock
+}
+
+output "kms_key_replica" {
+  description = "The KMS customer master key to encrypt replica bucket b."
+  value       = try(aws_kms_key.replica[0], null)
 }
 
 output "terraform_iam_policy" {

--- a/replica.tf
+++ b/replica.tf
@@ -47,6 +47,7 @@ resource "aws_iam_role" "replication" {
 }
 POLICY
 
+  permissions_boundary = var.iam_role_permissions_boundary
   tags = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,12 @@ variable "iam_role_arn" {
   default     = null
 }
 
+variable "iam_role_permissions_boundary" {
+  description = "Use permissions_boundary with the replication IAM role."
+  type        = string
+  default     = null
+}
+
 variable "iam_role_name_prefix" {
   description = "Creates a unique name beginning with the specified prefix."
   type        = string


### PR DESCRIPTION
Some organizations requires permission_boundary on iam_roles.
This allows the boundary arn to be specified.