### PR TITLE
Feature/iam policy boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ See [the official document](https://www.terraform.io/docs/backends/types/s3.html
 | <a name="input_iam_policy_name_prefix"></a> [iam\_policy\_name\_prefix](#input\_iam\_policy\_name\_prefix) | Creates a unique name beginning with the specified prefix. | `string` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | Use IAM role of specified ARN for s3 replication instead of creating it. | `string` | no |
 | <a name="input_iam_role_name_prefix"></a> [iam\_role\_name\_prefix](#input\_iam\_role\_name\_prefix) | Creates a unique name beginning with the specified prefix. | `string` | no |
+| <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | Use permissions\_boundary with the replication IAM role. | `string` | no |
 | <a name="input_kms_key_alias"></a> [kms\_key\_alias](#input\_kms\_key\_alias) | The alias for the KMS key as viewed in AWS console. It will be automatically prefixed with `alias/` | `string` | no |
 | <a name="input_kms_key_deletion_window_in_days"></a> [kms\_key\_deletion\_window\_in\_days](#input\_kms\_key\_deletion\_window\_in\_days) | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. | `number` | no |
 | <a name="input_kms_key_description"></a> [kms\_key\_description](#input\_kms\_key\_description) | The description of the key as viewed in AWS console. | `string` | no |

--- a/replica.tf
+++ b/replica.tf
@@ -47,6 +47,7 @@ resource "aws_iam_role" "replication" {
 }
 POLICY
 
+  permissions_boundary = var.iam_role_permissions_boundary
   tags = var.tags
 }
 

--- a/replica.tf
+++ b/replica.tf
@@ -48,7 +48,7 @@ resource "aws_iam_role" "replication" {
 POLICY
 
   permissions_boundary = var.iam_role_permissions_boundary
-  tags = var.tags
+  tags                 = var.tags
 }
 
 resource "aws_iam_policy" "replication" {

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,12 @@ variable "iam_role_arn" {
   default     = null
 }
 
+variable "iam_role_permissions_boundary" {
+  description = "Use permissions_boundary with the replication IAM role."
+  type        = string
+  default     = null
+}
+
 variable "iam_role_name_prefix" {
   description = "Creates a unique name beginning with the specified prefix."
   type        = string


### PR DESCRIPTION
Some organizations requires permission_boundary on iam_roles.
This allows the boundary arn to be specified.
