### PR TITLE
Fix kms_key_alias output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "kms_key" {
 
 output "kms_key_alias" {
   description = "The alias of the KMS customer master key used to encrypt state bucket and dynamodb."
-  value       = aws_kms_key.this
+  value       = aws_kms_alias.this
 }
 
 output "state_bucket" {


### PR DESCRIPTION
This PR fixes the output of the KMS Key Alias, which currently output the same thing as the KMS Key itself.

PS: On a side note, the KMS Key Alias is not set on the KMS Key in the replica region.