### PR TITLE
101 validate bucket names

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -187,7 +187,7 @@ variable "s3_bucket_name" {
   type        = string
   default     = ""
   validation {
-    condition     = !var.override_s3_bucket_name || length(regexall("(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.s3_bucket_name)) > 0
+    condition     = length(regexall("(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.s3_bucket_name)) > 0
     error_message = "Input variable s3_bucket_name is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
   }
 }
@@ -196,7 +196,7 @@ variable "s3_bucket_name_replica" {
   type        = string
   default     = ""
     validation {
-    condition     = !var.override_s3_bucket_name || length(regexall("(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.s3_bucket_name_replica)) > 0
+    condition     = length(regexall("(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.s3_bucket_name_replica)) > 0
     error_message = "Input variable s3_bucket_name_replica is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -187,7 +187,7 @@ variable "s3_bucket_name" {
   type        = string
   default     = ""
   validation {
-    condition     = length(regexall("^[A-Za-z0-9][A-Za-z0-9\-.]{1,61}[A-Za-z0-9]$", var.s3_bucket_name)) > 0
+    condition     = length(regexall("^[A-Za-z0-9][A-Za-z0-9\\-.]{1,61}[A-Za-z0-9]$", var.s3_bucket_name)) > 0
     error_message = "Input variable s3_bucket_name is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
   }
 }
@@ -196,7 +196,7 @@ variable "s3_bucket_name_replica" {
   type        = string
   default     = ""
     validation {
-    condition     = length(regexall("^[A-Za-z0-9][A-Za-z0-9\-.]{1,61}[A-Za-z0-9]$", var.s3_bucket_name_replica)) > 0
+    condition     = length(regexall("^[A-Za-z0-9][A-Za-z0-9\\-.]{1,61}[A-Za-z0-9]$", var.s3_bucket_name_replica)) > 0
     error_message = "Input variable s3_bucket_name_replica is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -187,17 +187,17 @@ variable "s3_bucket_name" {
   type        = string
   default     = ""
   validation {
-    condition     = length(regexall("^[A-Za-z0-9][A-Za-z0-9\\-.]{1,61}[A-Za-z0-9]$", var.s3_bucket_name)) > 0
-    error_message = "Input variable s3_bucket_name is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
+    condition     = length(regexall("^[a-z0-9][a-z0-9\\-.]{1,61}[a-z0-9]$", var.s3_bucket_name)) > 0
+    error_message = "Input variable s3_bucket_name is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html."
   }
 }
 variable "s3_bucket_name_replica" {
   description = "If override_s3_bucket_name is true, use this bucket name for replica instead of dynamic name with bucket_prefix"
   type        = string
   default     = ""
-    validation {
-    condition     = length(regexall("^[A-Za-z0-9][A-Za-z0-9\\-.]{1,61}[A-Za-z0-9]$", var.s3_bucket_name_replica)) > 0
-    error_message = "Input variable s3_bucket_name_replica is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
+  validation {
+    condition     = length(regexall("^[a-z0-9][a-z0-9\\-.]{1,61}[a-z0-9]$", var.s3_bucket_name_replica)) > 0
+    error_message = "Input variable s3_bucket_name_replica is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -187,7 +187,8 @@ variable "s3_bucket_name" {
   type        = string
   default     = ""
   validation {
-    condition     = length(regexall("(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.s3_bucket_name)) > 0
+    condition     = length(regexall("(?!^(\d{1,3}\.){3}\d{1,3}$)(^[a-z0-9]([a-z0-9-]*(\.[a-z0-9])?)*$)", var.s3_bucket_name)) > 0
+    # (?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"
     error_message = "Input variable s3_bucket_name is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
   }
 }
@@ -196,7 +197,8 @@ variable "s3_bucket_name_replica" {
   type        = string
   default     = ""
     validation {
-    condition     = length(regexall("(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.s3_bucket_name_replica)) > 0
+    condition     = length(regexall("(?!^(\d{1,3}\.){3}\d{1,3}$)(^[a-z0-9]([a-z0-9-]*(\.[a-z0-9])?)*$)", var.s3_bucket_name_replica)) > 0
+    # (?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"
     error_message = "Input variable s3_bucket_name_replica is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -187,8 +187,7 @@ variable "s3_bucket_name" {
   type        = string
   default     = ""
   validation {
-    condition     = length(regexall("(?!^(\\d{1,3}\\.){3}\\d{1,3}$)(^[a-z0-9]([a-z0-9-]*\\.[a-z0-9])?)*$)", var.s3_bucket_name)) > 0
-    # (?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"
+    condition     = length(regexall("^[A-Za-z0-9][A-Za-z0-9\-.]{1,61}[A-Za-z0-9]$", var.s3_bucket_name)) > 0
     error_message = "Input variable s3_bucket_name is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
   }
 }
@@ -197,8 +196,7 @@ variable "s3_bucket_name_replica" {
   type        = string
   default     = ""
     validation {
-    condition     = length(regexall("(?!^(\\d{1,3}\\.){3}\\d{1,3}$)(^[a-z0-9]([a-z0-9-]*(\\.[a-z0-9])?)*$)", var.s3_bucket_name_replica)) > 0
-    # (?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"
+    condition     = length(regexall("^[A-Za-z0-9][A-Za-z0-9\-.]{1,61}[A-Za-z0-9]$", var.s3_bucket_name_replica)) > 0
     error_message = "Input variable s3_bucket_name_replica is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -186,11 +186,19 @@ variable "s3_bucket_name" {
   description = "If override_s3_bucket_name is true, use this bucket name instead of dynamic name with bucket_prefix"
   type        = string
   default     = ""
+  validation {
+    condition     = !var.override_s3_bucket_name || length(regexall("(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.s3_bucket_name)) > 0
+    error_message = "Input variable s3_bucket_name is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
+  }
 }
 variable "s3_bucket_name_replica" {
   description = "If override_s3_bucket_name is true, use this bucket name for replica instead of dynamic name with bucket_prefix"
   type        = string
   default     = ""
+    validation {
+    condition     = !var.override_s3_bucket_name || length(regexall("(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.s3_bucket_name_replica)) > 0
+    error_message = "Input variable s3_bucket_name_replica is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
+  }
 }
 
 #---------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -187,7 +187,7 @@ variable "s3_bucket_name" {
   type        = string
   default     = ""
   validation {
-    condition     = length(regexall("(?!^(\d{1,3}\.){3}\d{1,3}$)(^[a-z0-9]([a-z0-9-]*(\.[a-z0-9])?)*$)", var.s3_bucket_name)) > 0
+    condition     = length(regexall("(?!^(\\d{1,3}\\.){3}\\d{1,3}$)(^[a-z0-9]([a-z0-9-]*\\.[a-z0-9])?)*$)", var.s3_bucket_name)) > 0
     # (?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"
     error_message = "Input variable s3_bucket_name is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
   }
@@ -197,7 +197,7 @@ variable "s3_bucket_name_replica" {
   type        = string
   default     = ""
     validation {
-    condition     = length(regexall("(?!^(\d{1,3}\.){3}\d{1,3}$)(^[a-z0-9]([a-z0-9-]*(\.[a-z0-9])?)*$)", var.s3_bucket_name_replica)) > 0
+    condition     = length(regexall("(?!^(\\d{1,3}\\.){3}\\d{1,3}$)(^[a-z0-9]([a-z0-9-]*(\\.[a-z0-9])?)*$)", var.s3_bucket_name_replica)) > 0
     # (?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"
     error_message = "Input variable s3_bucket_name_replica is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -187,7 +187,7 @@ variable "s3_bucket_name" {
   type        = string
   default     = ""
   validation {
-    condition     = length(regexall("^[a-z0-9][a-z0-9\\-.]{1,61}[a-z0-9]$", var.s3_bucket_name)) > 0
+    condition     = length(var.s3_bucket_name) == 0 || length(regexall("^[a-z0-9][a-z0-9\\-.]{1,61}[a-z0-9]$", var.s3_bucket_name)) > 0
     error_message = "Input variable s3_bucket_name is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html."
   }
 }
@@ -196,7 +196,7 @@ variable "s3_bucket_name_replica" {
   type        = string
   default     = ""
   validation {
-    condition     = length(regexall("^[a-z0-9][a-z0-9\\-.]{1,61}[a-z0-9]$", var.s3_bucket_name_replica)) > 0
+    condition     = length(var.s3_bucket_name_replica) == 0 || length(regexall("^[a-z0-9][a-z0-9\\-.]{1,61}[a-z0-9]$", var.s3_bucket_name_replica)) > 0
     error_message = "Input variable s3_bucket_name_replica is invalid. Please refer to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html."
   }
 }


### PR DESCRIPTION
Adds validation to bucket name input variables, following the [AWS Bucket Naming Rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). Currently, it allows `.` in case Transfer Accel is used. There may be other exceptions I have not covered, thus the review. I have tested this manually in my current project, that it produces the error when I include an `_` and does not when I remove the `_`.