### PR TITLE
Enable ACLs for new S3 buckets after AWS changed defaults

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -66,9 +66,18 @@ resource "aws_s3_bucket" "state" {
   tags = var.tags
 }
 
-resource "aws_s3_bucket_acl" "state" {
+resource "aws_s3_bucket_ownership_controls" "state" {
   bucket = aws_s3_bucket.state.id
-  acl    = "private"
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "state" {
+  depends_on = [aws_s3_bucket_ownership_controls.state]
+  bucket     = aws_s3_bucket.state.id
+  acl        = "private"
 }
 
 resource "aws_s3_bucket_versioning" "state" {

--- a/replica.tf
+++ b/replica.tf
@@ -173,9 +173,19 @@ resource "aws_s3_bucket" "replica" {
   tags = var.tags
 }
 
-resource "aws_s3_bucket_acl" "replica" {
-  count    = var.enable_replication ? 1 : 0
+resource "aws_s3_bucket_ownership_controls" "replica" {
+  bucket   = aws_s3_bucket.replica[0].id
   provider = aws.replica
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "replica" {
+  depends_on = [aws_s3_bucket_ownership_controls.replica]
+  count      = var.enable_replication ? 1 : 0
+  provider   = aws.replica
 
 
   bucket = aws_s3_bucket.replica[0].id


### PR DESCRIPTION
In April 2023, AWS has implemented changes to the default security settings for new S3 buckets: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

The new default setting, "Bucket owner enforced" disables bucket ACLs completely. This module relies on ACLs to require SSL connections only when communicating with the bucket. In order to retain this requirement, modify the object ownership settings to "Bucket owner preferred".

@see https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html