### PR TITLE
Update s3 lifecycle management

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -115,6 +115,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "state" {
     id     = "auto-archive"
     status = "Enabled"
 
+    filter {
+      prefix = ""
+    }
+
     dynamic "noncurrent_version_transition" {
       for_each = var.noncurrent_version_transitions
 

--- a/replica.tf
+++ b/replica.tf
@@ -229,6 +229,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "replica" {
     id     = "auto-archive"
     status = "Enabled"
 
+    filter {
+      prefix = ""
+    }
+
     dynamic "noncurrent_version_transition" {
       for_each = var.noncurrent_version_transitions
 
@@ -278,10 +282,6 @@ resource "aws_s3_bucket_replication_configuration" "state" {
   rule {
     id     = "replica_configuration"
     status = "Enabled"
-
-    filter {
-      prefix = ""
-    }
 
     delete_marker_replication {
       status = "Disabled"

--- a/replica.tf
+++ b/replica.tf
@@ -283,6 +283,8 @@ resource "aws_s3_bucket_replication_configuration" "state" {
     id     = "replica_configuration"
     status = "Enabled"
 
+    filter {}
+
     delete_marker_replication {
       status = "Disabled"
     }

--- a/replica.tf
+++ b/replica.tf
@@ -279,7 +279,9 @@ resource "aws_s3_bucket_replication_configuration" "state" {
     id     = "replica_configuration"
     status = "Enabled"
 
-    filter {}
+    filter {
+      prefix = ""
+    }
 
     delete_marker_replication {
       status = "Disabled"


### PR DESCRIPTION
We found out some warning:

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Invalid Attribute Combination
│
│   with module.remote_state.aws_s3_bucket_lifecycle_configuration.state,
│   on .terraform/modules/remote_state/bucket.tf line 110, in resource "aws_s3_bucket_lifecycle_configuration" "state":
│  110: resource "aws_s3_bucket_lifecycle_configuration" "state" {
│
│ No attribute specified when one (and only one) of [rule[0].filter,rule[0].prefix] is required
│
│ This will be an error in a future version of the provider
│
│ (and 3 more similar warnings elsewhere)